### PR TITLE
UE4.8 Previewにてコンパイルエラーになる箇所を修正

### DIFF
--- a/Plugins/SpriteStudio5/Source/SpriteStudio5Ed/Private/Viewer/SsProjectViewerCommands.cpp
+++ b/Plugins/SpriteStudio5/Source/SpriteStudio5Ed/Private/Viewer/SsProjectViewerCommands.cpp
@@ -1,6 +1,7 @@
 #include "SpriteStudio5EdPrivatePCH.h"
 #include "SsProjectViewerCommands.h"
 
+#define LOCTEXT_NAMESPACE ""
 
 void FSsProjectViewerCommands::RegisterCommands()
 {
@@ -9,3 +10,5 @@ void FSsProjectViewerCommands::RegisterCommands()
 	UI_COMMAND(NextFrame, "NextFrame", "Forward One Frame", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(DrawGrid, "Grid", "Draw Grid", EUserInterfaceActionType::ToggleButton, FInputGesture());
 }
+
+#undef LOCTEXT_NAMESPACE


### PR DESCRIPTION
UE4.8 Previewでビルドしてみたところコンパイルエラーが発生しました。
該当のマクロには、 "This macro requires LOCTEXT_NAMESPACE to be defined. If you don't want the command to be placed under a sub namespace, provide "" as the namespace." というコメントが追加されており、LOCTEXT_NAMESPACE "" という定義を一時的に定義して、undefを行うルールが必要になったようです。
4.7でもビルドができる事は確認していますが、問題がないか確認をしてからマージしていただけると幸いです。
